### PR TITLE
Replacing git protocol.

### DIFF
--- a/recipes-bsp/bootfiles/bootfiles%.bbappend
+++ b/recipes-bsp/bootfiles/bootfiles%.bbappend
@@ -1,5 +1,5 @@
 RPIFW_DATE = "20200122"
 SRCREV = "01ecfd2ba2b7cf3a2f4aa75ada895ee4a3e729f5"
 RPIFW_S = "${WORKDIR}/git"
-RPIFW_SRC_URI = "git://github.com/raspberrypi/firmware.git;protocol=git;branch=master"
+RPIFW_SRC_URI = "git://github.com/raspberrypi/firmware.git;protocol=https;branch=master"
 

--- a/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -8,7 +8,7 @@ SRCREV_meta = "a19886b00ea7d874fdd60d8e3435894bb16e6434"
 KMETA = "kernel-meta"
 
 SRC_URI = "\
-    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH} \
+    git://github.com/raspberrypi/linux.git;name=machine;branch=${LINUX_RPI_BRANCH};protocol=https \
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA} \
     file://powersave.cfg \
 "


### PR DESCRIPTION
Github will stop supporting git protocol.
https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

Changing git:// protocol to https://