### PR TITLE
Bootfile: remove rpi firmware version dependency with 20210421

### DIFF
--- a/conf/distro/include/raspberrypi_generic.conf
+++ b/conf/distro/include/raspberrypi_generic.conf
@@ -12,7 +12,6 @@ PACKAGECONFIG_append_pn-wpeframework-plugins = "\
 
 PACKAGECONFIG_append_pn-wpeframework-plugins-rdk = " messenger packager"
 
-BBMASK_append = " ${@bb.utils.contains('PREFERRED_VERSION_linux-raspberrypi', '5.10.%', '', 'recipes-bsp/bootfiles/bootfiles.bbappend', d)}"
 DISTROOVERRIDES .= ":${DISTRO_CODENAME}"
 
 # Select packages based on distro name selection

--- a/recipes-bsp/bootfiles/bootfiles.bbappend
+++ b/recipes-bsp/bootfiles/bootfiles.bbappend
@@ -1,6 +1,0 @@
-RPIFW_DATE = "20210421"
-SRCREV = "2ac4de4eaac5c1d1b25acec4a5e0a9fdb16f0c91"
-RPIFW_S = "${WORKDIR}/firmware-${SRCREV}"
-RPIFW_SRC_URI = "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz;downloadfilename=raspberrypi-firmware-${SRCREV}.tar.gz"
-
-SRC_URI[sha256sum] = "c687aa1b5127a8dc0773e8aefb1f009f24bf71ccb4c9e8b40a1d46cbbb7bee0c"


### PR DESCRIPTION
Currently the meta-wpe metrological build for rpi is using 20210421 as the rpi bootfirmware version. While testing got a regression with race car video playback in WebKitBrowser. Also found the same issue with latest firmware as well. So now reverting the firmware version back to 20200122 using [recipes-bsp](https://github.com/WebPlatformForEmbedded/meta-metrological-raspberrypi/tree/main/recipes-bsp)/[bootfiles](https://github.com/WebPlatformForEmbedded/meta-metrological-raspberrypi/tree/main/recipes-bsp/bootfiles)/bootfiles%.bbappend